### PR TITLE
Fixes https://nvd.nist.gov/vuln/detail/CVE-2020-13956

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.13</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
An original issue is posted here in the [rschreijer master](https://github.com/rschreijer/lutung/issues/105).

This seems to solve the CVE without any backwards compatibility problems.