### PR TITLE
CVE fix: Bumped up commons.io, junit + Java8 ready

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 	</parent>
 
     <properties>
-        <java-version>1.6</java-version>
+        <java-version>1.8</java-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -81,10 +81,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>commons-io</groupId>
 		    <artifactId>commons-io</artifactId>
-		    <version>2.5</version> <!-- 2.5 is the last version to support java 1.6 -->
+		    <version>2.7</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApi.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApi.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.controller;
 
@@ -26,68 +26,68 @@ public class MandrillMessagesApi {
 		this.key = key;
 		this.rootUrl = url;
 	}
-	
+
 	public MandrillMessagesApi(final String key) {
 		this(key, MandrillApi.rootUrl);
 	}
-	
+
 	/**
 	 * <p>Send a new transactional message through Mandrill.</p>
 	 * @param m The information on the message to send
-	 * @param async Enable a background sending mode that is optimized 
-	 * for bulk sending. In async mode, messages/send will immediately 
-	 * return a status of 'queued' for every recipient. To handle 
-	 * rejections when sending in async mode, set up a webhook for the 
-	 * 'reject' event. Defaults to false for messages with no more than 
-	 * 10 recipients; messages with more than 10 recipients are always 
+	 * @param async Enable a background sending mode that is optimized
+	 * for bulk sending. In async mode, messages/send will immediately
+	 * return a status of 'queued' for every recipient. To handle
+	 * rejections when sending in async mode, set up a webhook for the
+	 * 'reject' event. Defaults to false for messages with no more than
+	 * 10 recipients; messages with more than 10 recipients are always
 	 * sent asynchronously, regardless of the value of async.
-	 * @return An array of {@link MandrillMessageStatus} objects, one for 
-	 * each recipient containing the key 'email' 
-	 * ({@link MandrillMessageStatus#getEmail()}) and 
-	 * {@link MandrillMessageStatus#getStatus()} as either 'sent', 
+	 * @return An array of {@link MandrillMessageStatus} objects, one for
+	 * each recipient containing the key 'email'
+	 * ({@link MandrillMessageStatus#getEmail()}) and
+	 * {@link MandrillMessageStatus#getStatus()} as either 'sent',
 	 * 'queued', or 'rejected'.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillMessageStatus[] send(final MandrillMessage m, 
+	public MandrillMessageStatus[] send(final MandrillMessage m,
 			final Boolean async) throws MandrillApiError, IOException {
-	
+
 		return send(m, async, null, null);
-		
+
 	}
-	
+
 	/**
 	 * <p>Send a new transactional message through Mandrill.</p>
 	 * @param m The information on the message to send
-	 * @param async Enable a background sending mode that is optimized 
-	 * for bulk sending. In async mode, messages/send will immediately 
-	 * return a status of 'queued' for every recipient. To handle 
-	 * rejections when sending in async mode, set up a webhook for the 
-	 * 'reject' event. Defaults to false for messages with no more than 
-	 * 10 recipients; messages with more than 10 recipients are always 
+	 * @param async Enable a background sending mode that is optimized
+	 * for bulk sending. In async mode, messages/send will immediately
+	 * return a status of 'queued' for every recipient. To handle
+	 * rejections when sending in async mode, set up a webhook for the
+	 * 'reject' event. Defaults to false for messages with no more than
+	 * 10 recipients; messages with more than 10 recipients are always
 	 * sent asynchronously, regardless of the value of async.
-	 * @param ipPool The name of the dedicated ip pool that should be 
-	 * used to send the message. If you do not have any dedicated IPs, 
-	 * this parameter has no effect. If you specify a pool that does 
-	 * not exist, your default pool will be used instead. Set to 
+	 * @param ipPool The name of the dedicated ip pool that should be
+	 * used to send the message. If you do not have any dedicated IPs,
+	 * this parameter has no effect. If you specify a pool that does
+	 * not exist, your default pool will be used instead. Set to
 	 * <code>null</code> to ignore this parameter.
-	 * @param sendAt When this message should be sent. If you specify a 
-	 * time in the past, the message will be sent immediately. An 
-	 * additional fee applies for scheduled email, and this feature is 
-	 * only available to accounts with a positive balance. Set to 
+	 * @param sendAt When this message should be sent. If you specify a
+	 * time in the past, the message will be sent immediately. An
+	 * additional fee applies for scheduled email, and this feature is
+	 * only available to accounts with a positive balance. Set to
 	 * <code>null</code> to ignore this parameter.
-	 * @return An array of {@link MandrillMessageStatus} objects, one for 
-	 * each recipient containing the key 'email' 
-	 * ({@link MandrillMessageStatus#getEmail()}) and 
-	 * {@link MandrillMessageStatus#getStatus()} as either 'sent', 
+	 * @return An array of {@link MandrillMessageStatus} objects, one for
+	 * each recipient containing the key 'email'
+	 * ({@link MandrillMessageStatus#getEmail()}) and
+	 * {@link MandrillMessageStatus#getStatus()} as either 'sent',
 	 * 'queued', or 'rejected'.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillMessageStatus[] send(final MandrillMessage m, 
-			final Boolean async, final String ipPool, final Date sendAt) 
+	public MandrillMessageStatus[] send(final MandrillMessage m,
+			final Boolean async, final String ipPool, final Date sendAt)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("message", m);
 		params.put("async", async);
@@ -97,104 +97,104 @@ public class MandrillMessagesApi {
 		if(sendAt != null) {
 			params.put("send_at", sendAt);
 		}
-		return MandrillUtil.query(rootUrl+ "messages/send.json", 
+		return MandrillUtil.query(rootUrl+ "messages/send.json",
 				params, MandrillMessageStatus[].class);
-		
+
 	}
-	
-	
-	
+
+
+
 	/**
-	 * <p>Send a new transactional message through Mandrill 
+	 * <p>Send a new transactional message through Mandrill
 	 * using a template.</p>
-	 * @param templateName The name of a template that exists 
+	 * @param templateName The name of a template that exists
 	 * in the user's account; <b>Required</b>.
-	 * @param templateContent A map of template content to send. 
-	 * Each entry in the map should have the name of the content 
+	 * @param templateContent A map of template content to send.
+	 * Each entry in the map should have the name of the content
 	 * block to set the content for, corresponding to an mc:edit block,
 	 * and the actual content to put into the block. May be null.
-	 * @param m The other information on the message to send &ndash; 
-	 * same as {@link #send(MandrillMessage, Boolean)}, but without 
+	 * @param m The other information on the message to send &ndash;
+	 * same as {@link #send(MandrillMessage, Boolean)}, but without
 	 * the html content.
-	 * @param async Enable a background sending mode that is optimized 
-	 * for bulk sending. In async mode, messages/send will immediately 
-	 * return a status of 'queued' for every recipient. To handle 
-	 * rejections when sending in async mode, set up a webhook for the 
-	 * 'reject' event. Defaults to false for messages with no more than 
-	 * 10 recipients; messages with more than 10 recipients are always 
+	 * @param async Enable a background sending mode that is optimized
+	 * for bulk sending. In async mode, messages/send will immediately
+	 * return a status of 'queued' for every recipient. To handle
+	 * rejections when sending in async mode, set up a webhook for the
+	 * 'reject' event. Defaults to false for messages with no more than
+	 * 10 recipients; messages with more than 10 recipients are always
 	 * sent asynchronously, regardless of the value of async.
-	 * @return An array of {@link MandrillMessageStatus} objects, one for 
-	 * each recipient containing the key 'email' 
-	 * ({@link MandrillMessageStatus#getEmail()}) and 
-	 * {@link MandrillMessageStatus#getStatus()} as either 'sent', 
+	 * @return An array of {@link MandrillMessageStatus} objects, one for
+	 * each recipient containing the key 'email'
+	 * ({@link MandrillMessageStatus#getEmail()}) and
+	 * {@link MandrillMessageStatus#getStatus()} as either 'sent',
 	 * 'queued', or 'rejected'.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
 	public MandrillMessageStatus[] sendTemplate(
-			final String templateName, final Map<String,String> templateContent, 
-			final MandrillMessage m, final Boolean async) 
+			final String templateName, final Map<String,String> templateContent,
+			final MandrillMessage m, final Boolean async)
 					throws MandrillApiError, IOException {
-	
-		return sendTemplate(templateName, templateContent, m, 
+
+		return sendTemplate(templateName, templateContent, m,
 				async, null, null);
-		
+
 	}
-	
+
 	/**
-	 * <p>Send a new transactional message through Mandrill 
+	 * <p>Send a new transactional message through Mandrill
 	 * using a template.</p>
-	 * @param templateName The name of a template that exists 
+	 * @param templateName The name of a template that exists
 	 * in the user's account; <b>Required</b>.
-	 * @param templateContent A map of template content to send. 
-	 * Each entry in the map should have the name of the content 
+	 * @param templateContent A map of template content to send.
+	 * Each entry in the map should have the name of the content
 	 * block to set the content for, corresponding to an mc:edit block,
 	 * and the actual content to put into the block. May be null.
-	 * @param m The other information on the message to send &ndash; 
-	 * same as {@link #send(MandrillMessage, Boolean)}, but without 
+	 * @param m The other information on the message to send &ndash;
+	 * same as {@link #send(MandrillMessage, Boolean)}, but without
 	 * the html content.
-	 * @param async Enable a background sending mode that is optimized 
-	 * for bulk sending. In async mode, messages/send will immediately 
-	 * return a status of 'queued' for every recipient. To handle 
-	 * rejections when sending in async mode, set up a webhook for the 
-	 * 'reject' event. Defaults to false for messages with no more than 
-	 * 10 recipients; messages with more than 10 recipients are always 
+	 * @param async Enable a background sending mode that is optimized
+	 * for bulk sending. In async mode, messages/send will immediately
+	 * return a status of 'queued' for every recipient. To handle
+	 * rejections when sending in async mode, set up a webhook for the
+	 * 'reject' event. Defaults to false for messages with no more than
+	 * 10 recipients; messages with more than 10 recipients are always
 	 * sent asynchronously, regardless of the value of async.
-	 * @param ipPool The name of the dedicated ip pool that should be 
-	 * used to send the message. If you do not have any dedicated IPs, 
-	 * this parameter has no effect. If you specify a pool that does 
-	 * not exist, your default pool will be used instead. Set to 
+	 * @param ipPool The name of the dedicated ip pool that should be
+	 * used to send the message. If you do not have any dedicated IPs,
+	 * this parameter has no effect. If you specify a pool that does
+	 * not exist, your default pool will be used instead. Set to
 	 * <code>null</code> to ignore this parameter.
-	 * @param sendAt When this message should be sent. If you specify a 
-	 * time in the past, the message will be sent immediately. An 
-	 * additional fee applies for scheduled email, and this feature is 
-	 * only available to accounts with a positive balance. Set to 
+	 * @param sendAt When this message should be sent. If you specify a
+	 * time in the past, the message will be sent immediately. An
+	 * additional fee applies for scheduled email, and this feature is
+	 * only available to accounts with a positive balance. Set to
 	 * <code>null</code> to ignore this parameter.
-	 * @return An array of {@link MandrillMessageStatus} objects, one for 
-	 * each recipient containing the key 'email' 
-	 * ({@link MandrillMessageStatus#getEmail()}) and 
-	 * {@link MandrillMessageStatus#getStatus()} as either 'sent', 
+	 * @return An array of {@link MandrillMessageStatus} objects, one for
+	 * each recipient containing the key 'email'
+	 * ({@link MandrillMessageStatus#getEmail()}) and
+	 * {@link MandrillMessageStatus#getStatus()} as either 'sent',
 	 * 'queued', or 'rejected'.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
 	public MandrillMessageStatus[] sendTemplate(
-			final String templateName, final Map<String,String> templateContent, 
-			final MandrillMessage m, final Boolean async, 
-			final String ipPool, final Date sendAt) 
+			final String templateName, final Map<String,String> templateContent,
+			final MandrillMessage m, final Boolean async,
+			final String ipPool, final Date sendAt)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("template_name", templateName);
 		final ArrayList<TemplateContent> contents;
 		if(templateContent == null) {
-            contents = new ArrayList<MandrillMessagesApi.TemplateContent>(1);
+            contents = new ArrayList<>(1);
             // API requires at least one entry in the template_content array, even when unused
             contents.add( TemplateContent.create("satisfy_validation", "") );
         }
         else {
-            contents = new ArrayList<MandrillMessagesApi.TemplateContent>(
-					templateContent.size());
+            contents = new ArrayList<>(
+				templateContent.size());
 			for(String name : templateContent.keySet()) {
 				contents.add( TemplateContent.create(
 						name, templateContent.get(name)) );
@@ -211,22 +211,22 @@ public class MandrillMessagesApi {
 		}
 		return MandrillUtil.query( rootUrl + "messages/send-template.json",
                 params, MandrillMessageStatus[].class );
-		
+
 	}
-	
+
 	/**
-	 * <p>Search the content of recently sent messages and 
+	 * <p>Search the content of recently sent messages and
 	 * optionally narrow by date range, tags and senders.</p>
 	 * @param search Search parameters for message searching.
-	 * @return An array of {@link MandrillMessageInfo} objects 
+	 * @return An array of {@link MandrillMessageInfo} objects
 	 * containing found messages for the performed search.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
 	public MandrillMessageInfo[] search(
-			final MandrillSearchMessageParams search) 
+			final MandrillSearchMessageParams search)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		if(search != null) {
 			params.put("query", search.getQuery());
@@ -237,24 +237,24 @@ public class MandrillMessagesApi {
 			params.put("api_keys", search.getApiKeys());
 			params.put("limit", search.getLimit());
 		}
-		return MandrillUtil.query(rootUrl+ "messages/search.json", 
+		return MandrillUtil.query(rootUrl+ "messages/search.json",
 				params,	MandrillMessageInfo[].class);
-		
+
 	}
-	
+
 	/**
-	 * <p>Search the content of recently sent messages and return 
+	 * <p>Search the content of recently sent messages and return
 	 * the aggregated hourly stats for matching messages.</p>
 	 * @param search Search parameters for message searching.
-	 * @return An array of {@link MandrillTimeSeries} objects 
+	 * @return An array of {@link MandrillTimeSeries} objects
 	 * containing aggregated hourly stats for the matching messages.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
 	public MandrillTimeSeries[] searchTimeSeries(
-			final MandrillSearchMessageParams search) 
+			final MandrillSearchMessageParams search)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		if(search != null) {
 			params.put("query", search.getQuery());
@@ -263,27 +263,27 @@ public class MandrillMessagesApi {
 			params.put("tags", search.getTags());
 			params.put("senders", search.getSenders());
 		}
-		return MandrillUtil.query(rootUrl+ "messages/search-time-series.json", 
+		return MandrillUtil.query(rootUrl+ "messages/search-time-series.json",
 				params,	MandrillTimeSeries[].class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Get the information for a single recently sent message.</p>
-	 * @param id The unique id of the message to get &ndash; passed as 
+	 * @param id The unique id of the message to get &ndash; passed as
 	 * the '_id' field in webhooks, send calls, or search calls.
 	 * @return The information for the message.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillMessageInfo info(final String id) 
+	public MandrillMessageInfo info(final String id)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("id", id);
-		return MandrillUtil.query(rootUrl+ "messages/info.json", 
+		return MandrillUtil.query(rootUrl+ "messages/info.json",
 				params,	MandrillMessageInfo.class);
-		
+
 	}
 
     /**
@@ -305,26 +305,26 @@ public class MandrillMessagesApi {
     }
 
     /**
-	 * <p>Parse the full MIME document for an email message, 
-	 * returning the content of the message broken into 
+	 * <p>Parse the full MIME document for an email message,
+	 * returning the content of the message broken into
 	 * its constituent pieces.</p>
 	 * @param rawMessage The full MIME document of an email message.
 	 * @return The parsed message as a {@link MandrillMessage}.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillMessage parse(final String rawMessage) 
+	public MandrillMessage parse(final String rawMessage)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("raw_message", rawMessage);
 		return MandrillUtil.query(rootUrl+ "messages/parse.json",
 				params, MandrillMessage.class);
-		
+
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param fromEmail Optionally define the sender address - otherwise it'll use the
 	 *                     address found in the provided headers.
 	 * @param fromName Optionally define the sender alias.
@@ -337,23 +337,23 @@ public class MandrillMessagesApi {
 	 * @throws IOException IO Error
 	 * @since Mar 18, 2013
 	 */
-	public MandrillMessageStatus[] sendRaw(final String fromEmail, 
-			final String fromName, final String rawMessage, 
-			final Collection<String> to, final Boolean async) 
+	public MandrillMessageStatus[] sendRaw(final String fromEmail,
+			final String fromName, final String rawMessage,
+			final Collection<String> to, final Boolean async)
 					throws MandrillApiError, IOException {
-		
-		return sendRaw(fromEmail, fromName, rawMessage, to, async, 
+
+		return sendRaw(fromEmail, fromName, rawMessage, to, async,
 				null, null, null);
-		
+
 	}
-	
-	public MandrillMessageStatus[] sendRaw(final String fromEmail, 
-			final String fromName, final String rawMessage, 
+
+	public MandrillMessageStatus[] sendRaw(final String fromEmail,
+			final String fromName, final String rawMessage,
 			final Collection<String> to, final Boolean async,
-			final String ipPool, final Date sendAt, 
-			final String returnPathDomain) 
+			final String ipPool, final Date sendAt,
+			final String returnPathDomain)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("raw_message", rawMessage);
 		params.put("from_email", fromEmail);
@@ -369,11 +369,11 @@ public class MandrillMessagesApi {
 		if(returnPathDomain != null) {
 			params.put("return_path_domain", returnPathDomain);
 		}
-		return MandrillUtil.query(rootUrl+ "messages/send-raw.json", 
+		return MandrillUtil.query(rootUrl+ "messages/send-raw.json",
 				params,	MandrillMessageStatus[].class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Queries your scheduled emails by sender or recipient, or both.</p>
 	 * @param to An optional recipient address to restrict results to.
@@ -381,59 +381,59 @@ public class MandrillMessagesApi {
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillScheduledMessageInfo[] listScheduled(final String to) 
+	public MandrillScheduledMessageInfo[] listScheduled(final String to)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("to", to);
-		return MandrillUtil.query(rootUrl+ "messages/list-scheduled.json", 
+		return MandrillUtil.query(rootUrl+ "messages/list-scheduled.json",
 				params,	MandrillScheduledMessageInfo[].class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Cancels a scheduled email.</p>
-	 * @param id A scheduled email id, as returned by any of 
+	 * @param id A scheduled email id, as returned by any of
 	 * the messages/send calls or messages/list-scheduled.
 	 * @return Information about the scheduled email that was cancelled.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillScheduledMessageInfo cancelScheduled(final String id) 
+	public MandrillScheduledMessageInfo cancelScheduled(final String id)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("id", id);
-		return MandrillUtil.query(rootUrl+ "messages/cancel-scheduled.json", 
+		return MandrillUtil.query(rootUrl+ "messages/cancel-scheduled.json",
 				params,	MandrillScheduledMessageInfo.class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Reschedules a scheduled email.</p>
-	 * @param id A scheduled email id, as returned by any of 
+	 * @param id A scheduled email id, as returned by any of
 	 * the messages/send calls or messages/list-scheduled.
-	 * @param send_at The new UTC timestamp when the message should 
-	 * sent. Mandrill can't time travel, so if you specify a time in 
+	 * @param send_at The new UTC timestamp when the message should
+	 * sent. Mandrill can't time travel, so if you specify a time in
 	 * past the message will be sent immediately.
 	 * @return Information about the scheduled email that was cancelled.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillScheduledMessageInfo reschedule(final String id, 
+	public MandrillScheduledMessageInfo reschedule(final String id,
 			final Date send_at) throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("id", id);
 		params.put("send_at", send_at);
-		return MandrillUtil.query(rootUrl+ "messages/reschedule.json", 
+		return MandrillUtil.query(rootUrl+ "messages/reschedule.json",
 				params,	MandrillScheduledMessageInfo.class);
-		
+
 	}
-	
+
 	public static final class TemplateContent {
 		private String name, content;
-		
+
 		/**
 		 * @return The name of the content.
 		 */
@@ -449,7 +449,7 @@ public class MandrillMessagesApi {
 
 		protected static final TemplateContent create(
 				final String name, final String content) {
-			
+
 			final TemplateContent c = new TemplateContent();
 			c.name = name;
 			c.content = content;

--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApi.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApi.java
@@ -27,7 +27,7 @@ public class MandrillTemplatesApi {
 		this.key = key;
 		this.rootUrl = url;
 	}
-	
+
 	public MandrillTemplatesApi(final String key) {
 		this(key, MandrillApi.rootUrl);
 	}
@@ -314,7 +314,7 @@ public class MandrillTemplatesApi {
 		params.put("template_name", name);
 		if(templateContent != null && !templateContent.isEmpty()) {
 			final ArrayList<MandrillContentWrapper> contents =
-					new ArrayList<MandrillContentWrapper>(templateContent.size());
+				new ArrayList<>(templateContent.size());
 			for(String cName : templateContent.keySet()) {
 				contents.add( MandrillContentWrapper.create(
 						cName, templateContent.get(cName)) );
@@ -323,7 +323,7 @@ public class MandrillTemplatesApi {
 		}
 		if(mergeVars != null && !mergeVars.isEmpty()) {
 			final ArrayList<MandrillContentWrapper> vars =
-					new ArrayList<MandrillContentWrapper>(mergeVars.size());
+				new ArrayList<>(mergeVars.size());
 			for(String cName : mergeVars.keySet()) {
 				vars.add( MandrillContentWrapper.create(
 						cName, mergeVars.get(cName)) );

--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillUtil.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillUtil.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.controller;
 
@@ -21,12 +21,12 @@ final class MandrillUtil {
 	 * @return
 	 */
 	protected static final HashMap<String,Object> paramsWithKey(final String key) {
-		final HashMap<String,Object> params = new HashMap<String,Object>();
+		final HashMap<String,Object> params = new HashMap<>();
 		params.put("key",key);
 		return params;
 
 	}
-	
+
 	/**
 	 * @param url
 	 * @param params
@@ -35,13 +35,13 @@ final class MandrillUtil {
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	protected static final <OUT> OUT query(final String url, 
-			final Map<String,Object> params, Class<OUT> responseType) 
+	protected static final <OUT> OUT query(final String url,
+			final Map<String,Object> params, Class<OUT> responseType)
 					throws MandrillApiError, IOException {
-		
-		final MandrillRequest<OUT> requestModel = 
-				new MandrillRequest<OUT>(url, params, responseType);
+
+		final MandrillRequest<OUT> requestModel =
+			new MandrillRequest<>(url, params, responseType);
 		return MandrillRequestDispatcher.execute(requestModel);
-		
+
 	}
 }

--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillWebhooksApi.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillWebhooksApi.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.controller;
 
@@ -24,99 +24,99 @@ public class MandrillWebhooksApi {
 		this.key = key;
 		this.rootUrl = url;
 	}
-	
+
 	public MandrillWebhooksApi(final String key) {
 		this(key, MandrillApi.rootUrl);
 	}
-	
+
 	/**
 	 * <p>Get the list of all webhooks defined for this account.</p>
 	 * @return An array of {@link MandrillWebhook} objects.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook[] list() throws MandrillApiError, 
+	public MandrillWebhook[] list() throws MandrillApiError,
 			IOException {
-		
+
 		return MandrillUtil.query(
-				rootUrl+ "webhooks/list.json", 
-				MandrillUtil.paramsWithKey(key), 
+				rootUrl+ "webhooks/list.json",
+				MandrillUtil.paramsWithKey(key),
 				MandrillWebhook[].class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Add a new webhook.</p>
 	 * @param url The URL to POST batches of events.
-	 * @param event An optional event that will be posted 
+	 * @param event An optional event that will be posted
 	 * to the webhook. You can use
-	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE}, 
-	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN}, 
-	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM}, 
-	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT} 
+	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE},
+	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN},
+	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM},
+	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT}
 	 * as valid events.
 	 * @return A {@link MandrillWebhook} object with info about the new webhook.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook add(final String url, final String event) 
+	public MandrillWebhook add(final String url, final String event)
 			throws MandrillApiError, IOException {
-		
-		final ArrayList<String> events = new ArrayList<String>(1);
+
+		final ArrayList<String> events = new ArrayList<>(1);
 		events.add(event);
 		return add(url, null, events);
-		
+
 	}
-	
+
 	/**
 	 * <p>Add a new webhook.</p>
 	 * @param url The URL to POST batches of events.
-	 * @param events An optional collection of events 
+	 * @param events An optional collection of events
 	 * that will be posted to the webhook. You can use
-	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE}, 
-	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN}, 
-	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM}, 
-	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT} 
+	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE},
+	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN},
+	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM},
+	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT}
 	 * as valid events.
 	 * @return A {@link MandrillWebhook} object with info about the new webhook.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook add(final String url, 
-			final Collection<String> events) throws MandrillApiError, 
+	public MandrillWebhook add(final String url,
+			final Collection<String> events) throws MandrillApiError,
 			IOException {
-		
+
 		return add(url, null, events);
-		
+
 	}
-	
+
 	/**
 	 * <p>Add a new webhook.</p>
 	 * @param url The URL to POST batches of events.
 	 * @param description An optional description of the webhook.
-	 * @param events An optional array of events that will 
+	 * @param events An optional array of events that will
 	 * be posted to the webhook. You can use
-	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE}, 
-	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN}, 
-	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM}, 
-	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT} 
+	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE},
+	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN},
+	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM},
+	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT}
 	 * as valid events.
 	 * @return A {@link MandrillWebhook} object with info about the new webhook.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook add(final String url, final String description, 
+	public MandrillWebhook add(final String url, final String description,
 			final Collection<String> events) throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("url", url);
 		params.put("description", description);
 		params.put("events", events);
-		return MandrillUtil.query(rootUrl+ "webhooks/add.json", 
+		return MandrillUtil.query(rootUrl+ "webhooks/add.json",
 				params, MandrillWebhook.class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Get the data about an existing webhook.</p>
 	 * @param id The unique identifier of a webhook belonging to this account.
@@ -124,43 +124,43 @@ public class MandrillWebhooksApi {
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook info(final Integer id) 
+	public MandrillWebhook info(final Integer id)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("id", id);
-		return MandrillUtil.query(rootUrl+ "webhooks/info.json", 
+		return MandrillUtil.query(rootUrl+ "webhooks/info.json",
 				params, MandrillWebhook.class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Update an existing webhook.</p>
 	 * @param id The unique identifier of a webhook belonging to this account.
 	 * @param url The URL to POST batches of events.
 	 * @param event An optional events that will be posted to the webhook. You can use
-	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE}, 
-	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN}, 
-	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM}, 
-	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT} 
+	 * {@link MandrillWebhook#SEND}, {@link MandrillWebhook#HARD_BOUNCE},
+	 * {@link MandrillWebhook#SOFT_BOUNCE}, {@link MandrillWebhook#OPEN},
+	 * {@link MandrillWebhook#CLICK}, {@link MandrillWebhook#SPAM},
+	 * {@link MandrillWebhook#UNSUB} and {@link MandrillWebhook#REJECT}
 	 * as valid events.
 	 * @return A {@link MandrillWebhook} object with info about the webhook.
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook update(final Integer id, 
-			final String url, final String event) 
+	public MandrillWebhook update(final Integer id,
+			final String url, final String event)
 					throws MandrillApiError, IOException {
-		
-		final ArrayList<String> events = new ArrayList<String>(1);
+
+		final ArrayList<String> events = new ArrayList<>(1);
 		events.add(event);
 		return update(id, url, events);
-		
+
 	}
-	
+
 	/**
 	 * <p>Update an existing webhook.</p>
-	 * @param id The unique identifier of a webhook 
+	 * @param id The unique identifier of a webhook
 	 * belonging to this account.
 	 * @param url The URL to POST batches of events.
 	 * @param events An optional collection of events that will be posted to the webhook.
@@ -168,14 +168,14 @@ public class MandrillWebhooksApi {
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook update(final Integer id, 
-			final String url, final Collection<String> events) 
+	public MandrillWebhook update(final Integer id,
+			final String url, final Collection<String> events)
 					throws MandrillApiError, IOException {
-		
+
 		return update(id, url, null, events);
-		
+
 	}
-	
+
 	/**
 	 * <p>Update an existing webhook.</p>
 	 * @param id The unique identifier of a webhook belonging to this account.
@@ -186,20 +186,20 @@ public class MandrillWebhooksApi {
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook update(final Integer id, final String url, 
-			final String description, final Collection<String> events) 
+	public MandrillWebhook update(final Integer id, final String url,
+			final String description, final Collection<String> events)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("id", id);
 		params.put("url", url);
 		params.put("description", description);
 		params.put("events", events);
-		return MandrillUtil.query(rootUrl+ "webhooks/update.json", 
+		return MandrillUtil.query(rootUrl+ "webhooks/update.json",
 				params, MandrillWebhook.class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Delete an existing webhook.</p>
 	 * @param id The unique identifier of a webhook belonging to this account.
@@ -207,13 +207,13 @@ public class MandrillWebhooksApi {
 	 * @throws MandrillApiError Mandrill API Error
 	 * @throws IOException IO Error
 	 */
-	public MandrillWebhook delete(final Integer id) 
+	public MandrillWebhook delete(final Integer id)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("id", id);
-		return MandrillUtil.query(rootUrl+ "webhooks/delete.json", 
+		return MandrillUtil.query(rootUrl+ "webhooks/delete.json",
 				params, MandrillWebhook.class);
-		
+
 	}
 }

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
@@ -64,7 +64,7 @@ public final class LutungGsonUtils {
 
 			if(!json.isJsonPrimitive()) {
 				throw new JsonParseException(
-						"Unexpected type for date: " +json.toString());
+						"Unexpected type for date: " + json);
 
 			}
 			try {
@@ -118,7 +118,7 @@ public final class LutungGsonUtils {
 
 			if(!json.isJsonPrimitive()) {
 				throw new JsonParseException(
-						"Unexpected type for recipient type: " +json.toString());
+						"Unexpected type for recipient type: " + json);
 			}
 
 			return MandrillMessage.Recipient.Type.valueOf(

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
@@ -1,17 +1,14 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.model;
 
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.SocketConfig;
-import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
@@ -21,7 +18,6 @@ import com.microtripit.mandrillapp.lutung.logging.LoggerFactory;
 import com.microtripit.mandrillapp.lutung.model.MandrillApiError.MandrillError;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -62,7 +58,7 @@ public final class MandrillRequestDispatcher {
 
 	private static int getSystemProperty(String name, String defaultValue) {
 		String value = System.getProperty(name, defaultValue);
-		return Integer.valueOf(value);
+		return Integer.parseInt(value);
 	}
 
 	static {
@@ -91,8 +87,8 @@ public final class MandrillRequestDispatcher {
 			final ProxyData proxyData = detectProxyServer(requestModel.getUrl());
 			if (proxyData != null) {
 				if (log.isDebugEnabled()) {
-					log.debug(String.format("Using proxy @" + proxyData.host
-							+ ":" + String.valueOf(proxyData.port)));
+					log.debug("Using proxy @" + proxyData.host
+							+ ":" + proxyData.port);
 				}
 				final HttpHost proxy = new HttpHost(proxyData.host,
 						proxyData.port);
@@ -112,14 +108,14 @@ public final class MandrillRequestDispatcher {
 			if( requestModel.validateResponseStatus(status.getStatusCode()) ) {
 				try {
 					return requestModel.handleResponse( responseString );
-					
+
 				} catch(final HandleResponseException e) {
 					throw new IOException(
-							"Failed to parse response from request '" 
+							"Failed to parse response from request '"
 							+requestModel.getUrl()+ "'", e);
-					
+
 				}
-				
+
 			} else {
 				// ==> compile mandrill error!
 				MandrillError error = null;
@@ -134,12 +130,12 @@ public final class MandrillRequestDispatcher {
 				}
 
 				throw new MandrillApiError(
-						"Unexpected http status in response: " 
-						+status.getStatusCode()+ " (" 
+						"Unexpected http status in response: "
+						+status.getStatusCode()+ " ("
 						+status.getReasonPhrase()+ ")").withError(error);
-				
+
 			}
-				
+
 		} finally {
 			try {
 				if (response != null) {

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/RequestModel.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/RequestModel.java
@@ -1,44 +1,42 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.model;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
 /**
- * 
+ *
  * @author rschreijer
  * @since Jan 7, 2013
  * @param <V> The type that response-data/ response-content is parsed to.
  */
 public interface RequestModel<V> {
-	
+
 	/**
 	 * @return The url for this request, as {@link String}.
 	 */
-	public String getUrl();
+	String getUrl();
 
 	/**
-	 * @return The request object describing the request to 
+	 * @return The request object describing the request to
 	 * be made w/ a http client.
 	 * @throws IOException IO Error
 	 * @since Mar 22, 2013
 	 */
-	public HttpRequestBase getRequest() throws IOException;
-	
+	HttpRequestBase getRequest() throws IOException;
+
 	/**
-	 * <p>Checks weather the response-status is as-expected 
+	 * <p>Checks weather the response-status is as-expected
 	 * for this request.</p>
 	 * @param httpResponseStatus The HTTP response status
 	 * @return <code>true</code> if the response status is as expected,
 	 * <code>false</code> otherwise.
 	 */
-	public boolean validateResponseStatus(int httpResponseStatus);
-	
+	boolean validateResponseStatus(int httpResponseStatus);
+
 	/**
 	 * <p>Parses the content/data of this request's response into
 	 * a desired format {@link V}.
@@ -46,6 +44,6 @@ public interface RequestModel<V> {
 	 * @return
 	 * @throws HandleResponseException
 	 */
-	public V handleResponse(String responseString) throws HandleResponseException;
-	
+	V handleResponse(String responseString) throws HandleResponseException;
+
 }

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
@@ -1,9 +1,10 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.view;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -16,9 +17,9 @@ public class MandrillMessage {
 	private String subject, html, text, from_email, from_name;
 	private List<Recipient> to;
 	private Map<String,String> headers;
-	private Boolean important, track_opens, track_clicks, auto_text, auto_html, 
+	private Boolean important, track_opens, track_clicks, auto_text, auto_html,
 			inline_css, url_strip_qs, preserve_recipients, view_content_link;
-	private String bcc_address, tracking_domain, signing_domain, 
+	private String bcc_address, tracking_domain, signing_domain,
 			return_path_domain;
 	private Boolean merge;
 	private String merge_language;
@@ -33,8 +34,8 @@ public class MandrillMessage {
 	private List<MessageContent> attachments;
 	private List<MessageContent> images;
 	// following params are send-only
-	
-	
+
+
 	/**
 	 * @return The message subject.
 	 */
@@ -118,10 +119,10 @@ public class MandrillMessage {
 	public void setTo(final List<Recipient> to) {
 		this.to = to;
 	}
-	
+
 	/**
-	 * @return Optional extra headers to add to the 
-	 * message (currently only Reply-To and X-* headers 
+	 * @return Optional extra headers to add to the
+	 * message (currently only Reply-To and X-* headers
 	 * are allowed).
 	 */
 	public Map<String,String> getHeaders() {
@@ -129,8 +130,8 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param headers Optional extra headers to add to the 
-	 * message (currently only Reply-To and X-* headers 
+	 * @param headers Optional extra headers to add to the
+	 * message (currently only Reply-To and X-* headers
 	 * are allowed)
 	 */
 	public void setHeaders(final Map<String,String> headers) {
@@ -164,17 +165,17 @@ public class MandrillMessage {
 	public void setImages(final List<MessageContent> images) {
 		this.images = images;
 	}
-	
+
 	/**
-	 * @return Whether or not this message is important, and should be 
+	 * @return Whether or not this message is important, and should be
 	 * delivered ahead of non-important messages.
 	 */
 	public Boolean getImportant() {
 		return important;
 	}
-	
+
 	/**
-	 * @param important Set whether or not this message is important, and 
+	 * @param important Set whether or not this message is important, and
 	 * should be delivered ahead of non-important messages
 	 */
 	public void setImportant(final Boolean important) {
@@ -182,7 +183,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return Whether or not to turn on open tracking 
+	 * @return Whether or not to turn on open tracking
 	 * for the message.
 	 */
 	public Boolean getTrackOpens() {
@@ -190,7 +191,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param trackOpens Whether or not to turn on open 
+	 * @param trackOpens Whether or not to turn on open
 	 * tracking for the message.
 	 */
 	public void setTrackOpens(final Boolean trackOpens) {
@@ -198,7 +199,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	* @return Whether or not to turn on click tracking 
+	* @return Whether or not to turn on click tracking
 	* for the message.
 	*/
 	public Boolean getTrackClicks() {
@@ -206,7 +207,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param trackClicks Whether or not to turn on click tracking 
+	 * @param trackClicks Whether or not to turn on click tracking
 	* for the message.
 	 */
 	public void setTrackClicks(final Boolean trackClicks) {
@@ -214,7 +215,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return Whether or not to automatically generate a 
+	 * @return Whether or not to automatically generate a
 	 * text part for messages that are not given text.
 	 */
 	public Boolean getAutoText() {
@@ -222,7 +223,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param autoText Whether or not to automatically generate a 
+	 * @param autoText Whether or not to automatically generate a
 	 * text part for messages that are not given text.
 	 */
 	public void setAutoText(final Boolean autoText) {
@@ -230,7 +231,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return Whether or not to automatically generate an 
+	 * @return Whether or not to automatically generate an
 	 * HTML part for messages that are not given HTML.
 	 */
 	public Boolean getAutoHtml() {
@@ -238,7 +239,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param autoHtml Whether or not to automatically generate an 
+	 * @param autoHtml Whether or not to automatically generate an
 	 * HTML part for messages that are not given HTML.
 	 */
 	public void setAutoHtml(final Boolean autoHtml) {
@@ -246,8 +247,8 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return Whether or not to automatically inline all CSS styles 
-	 * provided in the message HTML &ndash; only for HTML documents less 
+	 * @return Whether or not to automatically inline all CSS styles
+	 * provided in the message HTML &ndash; only for HTML documents less
 	 * than 256KB in size.
 	 */
 	public Boolean getInlineCss() {
@@ -255,8 +256,8 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param inlineCss Whether or not to automatically inline all CSS 
-	 * styles provided in the message HTML &ndash; only for HTML 
+	 * @param inlineCss Whether or not to automatically inline all CSS
+	 * styles provided in the message HTML &ndash; only for HTML
 	 * documents less than 256KB in size.
 	 */
 	public void setInlineCss(final Boolean inlineCss) {
@@ -264,7 +265,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return Whether or not to strip the query string 
+	 * @return Whether or not to strip the query string
 	 * from URLs when aggregating tracked URL data.
 	 */
 	public Boolean getUrlStripQs() {
@@ -272,7 +273,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param urlStripQs Whether or not to strip the query string 
+	 * @param urlStripQs Whether or not to strip the query string
 	 * from URLs when aggregating tracked URL data.
 	 */
 	public void setUrlStripQs(final Boolean urlStripQs) {
@@ -280,7 +281,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return Whether or not to expose all recipients in 
+	 * @return Whether or not to expose all recipients in
 	 * to "To" header for each email.
 	 */
 	public Boolean getPreserveRecipients() {
@@ -288,23 +289,23 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param preserveRecipients Whether or not to expose all 
+	 * @param preserveRecipients Whether or not to expose all
 	 * recipients in the "To" header for each email.
 	 */
 	public void setPreserveRecipients(final Boolean preserveRecipients) {
 		this.preserve_recipients = preserveRecipients;
 	}
-	
+
 	/**
-	 * @return False if you want to remove content logging for 
+	 * @return False if you want to remove content logging for
 	 * sensitive emails.
 	 */
 	public Boolean getViewContentLink() {
 		return view_content_link;
 	}
-	
+
 	/**
-	 * @param view_content_link Set to false to remove content logging for 
+	 * @param view_content_link Set to false to remove content logging for
 	 * sensitive emails.
 	 */
 	public void setViewContentLink(final Boolean view_content_link) {
@@ -312,7 +313,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return An optional address to receive an exact copy of 
+	 * @return An optional address to receive an exact copy of
 	 * each recipient's email.
 	 */
 	public String getBcc() {
@@ -320,7 +321,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param email An optional address to receive an 
+	 * @param email An optional address to receive an
 	 * exact copy of each recipient's email.
 	 */
 	public void setBcc(final String email) {
@@ -328,7 +329,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return A custom domain to use for tracking opens 
+	 * @return A custom domain to use for tracking opens
 	 * and clicks instead of mandrillapp.com.
 	 */
 	public String getTrackingDomain() {
@@ -336,7 +337,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param trackingDomain The custom domain to use for tracking 
+	 * @param trackingDomain The custom domain to use for tracking
 	 * opens and clicks instead of mandrillapp.com.
 	 */
 	public void setTrackingDomain(final String trackingDomain) {
@@ -344,7 +345,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return A custom domain to use for SPF/DKIM signing instead of 
+	 * @return A custom domain to use for SPF/DKIM signing instead of
 	 * mandrill (for "via" or "on behalf of" in email clients).
 	 */
 	public String getSigningDomain() {
@@ -352,23 +353,23 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param signingDomain The custom domain to use for SPF/DKIM 
-	 * signing instead of mandrill (for "via" or "on behalf of" 
+	 * @param signingDomain The custom domain to use for SPF/DKIM
+	 * signing instead of mandrill (for "via" or "on behalf of"
 	 * in email clients).
 	 */
 	public void setSigningDomain(final String signingDomain) {
 		this.signing_domain = signingDomain;
 	}
-	
+
 	/**
 	 * @return The custom domain to use for the messages's return-path.
 	 */
 	public String getReturnPathDomain() {
 		return return_path_domain;
 	}
-	
+
 	/**
-	 * @param return_path_domain A custom domain to use for the 
+	 * @param return_path_domain A custom domain to use for the
 	 * messages's return-path.
 	 */
 	public void setReturnPathDomain(final String return_path_domain) {
@@ -405,7 +406,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return The global merge variables to use for all recipients. 
+	 * @return The global merge variables to use for all recipients.
 	 * You can override these per recipient.
 	 */
 	public List<MergeVar> getGlobalMergeVars() {
@@ -413,7 +414,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param globalMergeVars The global merge variables to use for 
+	 * @param globalMergeVars The global merge variables to use for
 	 * all recipients. You can override these per recipient.
 	 */
 	public void setGlobalMergeVars(final List<MergeVar> globalMergeVars) {
@@ -421,7 +422,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return The per-recipient merge variables, which override 
+	 * @return The per-recipient merge variables, which override
 	 * global merge variables with the same name.
 	 */
 	public List<MergeVarBucket> getMergeVars() {
@@ -429,7 +430,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param mergeVars The per-recipient merge variables, which override 
+	 * @param mergeVars The per-recipient merge variables, which override
 	 * global merge variables with the same name.
 	 */
 	public void setMergeVars(final List<MergeVarBucket> mergeVars) {
@@ -437,11 +438,11 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return An array of string to tag the message with. Stats 
-	 * are accumulated using tags, though we only store the first 
-	 * 100 we see, so this should not be unique or change frequently. 
-	 * Tags should be 50 characters or less. Any tags starting with 
-	 * an underscore are reserved for internal use and will cause 
+	 * @return An array of string to tag the message with. Stats
+	 * are accumulated using tags, though we only store the first
+	 * 100 we see, so this should not be unique or change frequently.
+	 * Tags should be 50 characters or less. Any tags starting with
+	 * an underscore are reserved for internal use and will cause
 	 * errors.
 	 */
 	public List<String> getTags() {
@@ -449,47 +450,45 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param tags An array of string to tag the message with. Stats 
-	 * are accumulated using tags, though we only store the first 
-	 * 100 we see, so this should not be unique or change frequently. 
-	 * Tags should be 50 characters or less. Any tags starting with 
-	 * an underscore are reserved for internal use and will cause 
+	 * @param tags An array of string to tag the message with. Stats
+	 * are accumulated using tags, though we only store the first
+	 * 100 we see, so this should not be unique or change frequently.
+	 * Tags should be 50 characters or less. Any tags starting with
+	 * an underscore are reserved for internal use and will cause
 	 * errors.
 	 */
 	public void setTags(final List<String> tags) {
 		this.tags = tags;
 	}
-	
+
 	/**
-	 * @param tags Strings to tag the message with. Stats 
-	 * are accumulated using tags, though we only store the first 
-	 * 100 we see, so this should not be unique or change frequently. 
-	 * Tags should be 50 characters or less. Any tags starting with 
-	 * an underscore are reserved for internal use and will cause 
+	 * @param tags Strings to tag the message with. Stats
+	 * are accumulated using tags, though we only store the first
+	 * 100 we see, so this should not be unique or change frequently.
+	 * Tags should be 50 characters or less. Any tags starting with
+	 * an underscore are reserved for internal use and will cause
 	 * errors.
 	 */
 	public void setTags(final String... tags) {
-		final ArrayList<String> ts = new ArrayList<String>();
-		for(String tag : tags) {
-			ts.add(tag);
-		}
+		final ArrayList<String> ts = new ArrayList<>();
+		Collections.addAll(ts, tags);
 		if(!ts.isEmpty()) {
 			this.tags = ts;
 		} else {
 			this.tags = null;
 		}
 	}
-	
+
 	/**
-	 * @return The unique id of a subaccount for this message 
+	 * @return The unique id of a subaccount for this message
 	 * &ndash; must already exist or will fail with an error.
 	 */
 	public String getSubaccount() {
 		return subaccount;
 	}
-	
+
 	/**
-	 * @param subaccount The unique id of a subaccount for this message 
+	 * @param subaccount The unique id of a subaccount for this message
 	 * &ndash; must already exist or will fail with an error.
 	 */
 	public void setSubaccount(final String subaccount) {
@@ -497,8 +496,8 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return An array of strings indicating which matching URLs will 
-	 * automatically have Google Analytics parameters appended to their 
+	 * @return An array of strings indicating which matching URLs will
+	 * automatically have Google Analytics parameters appended to their
 	 * query string.
 	 */
 	public List<String> getGoogleAnalyticsDomains() {
@@ -506,19 +505,19 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param googleAnalyticsDomains An array of strings indicating which 
-	 * matching URLs will automatically have Google Analytics parameters 
+	 * @param googleAnalyticsDomains An array of strings indicating which
+	 * matching URLs will automatically have Google Analytics parameters
 	 * appended to their query string.
 	 */
 	public void setGoogleAnalyticsDomains(
 			final List<String> googleAnalyticsDomains) {
-		
+
 		this.google_analytics_domains = googleAnalyticsDomains;
 	}
 
 	/**
-	 * @return Optional string indicating the value to set 
-	 * for the utm_campaign tracking parameter. If this isn't 
+	 * @return Optional string indicating the value to set
+	 * for the utm_campaign tracking parameter. If this isn't
 	 * provided the email's from address will be used instead.
 	 */
 	public String getGoogleAnalyticsCampaign() {
@@ -526,20 +525,20 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param googleAnalyticsCampaign Optional string indicating the 
-	 * value to set for the utm_campaign tracking parameter. If this isn't 
+	 * @param googleAnalyticsCampaign Optional string indicating the
+	 * value to set for the utm_campaign tracking parameter. If this isn't
 	 * provided the email's from address will be used instead.
 	 */
 	public void setGoogleAnalyticsCampaign(
 			final String googleAnalyticsCampaign) {
-		
+
 		this.google_analytics_campaign = googleAnalyticsCampaign;
 	}
 
 	/**
-	 * @return A map of user metadata. Mandrill will 
-	 * store this metadata and make it available for retrieval. In 
-	 * addition, you can select up to 10 metadata fields to index and 
+	 * @return A map of user metadata. Mandrill will
+	 * store this metadata and make it available for retrieval. In
+	 * addition, you can select up to 10 metadata fields to index and
 	 * make searchable using the Mandrill search api.
 	 */
 	public Map<String, String> getMetadata() {
@@ -547,9 +546,9 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param metadata A map of user metadata. Mandrill will 
-	 * store this metadata and make it available for retrieval. In 
-	 * addition, you can select up to 10 metadata fields to index and 
+	 * @param metadata A map of user metadata. Mandrill will
+	 * store this metadata and make it available for retrieval. In
+	 * addition, you can select up to 10 metadata fields to index and
 	 * make searchable using the Mandrill search api.
 	 */
 	public void setMetadata(final Map<String, String> metadata) {
@@ -557,7 +556,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @return Per-recipient metadata that will override the 
+	 * @return Per-recipient metadata that will override the
 	 * global values specified in the metadata parameter.
 	 */
 	public List<RecipientMetadata> getRecipientMetadata() {
@@ -565,7 +564,7 @@ public class MandrillMessage {
 	}
 
 	/**
-	 * @param recipientMetadata metadata that will override the 
+	 * @param recipientMetadata metadata that will override the
 	 * global values specified in the metadata parameter.
 	 */
 	public void setRecipientMetadata(
@@ -573,7 +572,7 @@ public class MandrillMessage {
 		this.recipient_metadata = recipientMetadata;
 	}
 
-	
+
 
 	/**
 	 * <p>A single recipient's information.</p>
@@ -633,7 +632,7 @@ public class MandrillMessage {
 
 
 	}
-	
+
 	/**
 	 * <p>A single supported content object for a message. This
 	 * can be a embedded image or an attachment.</p>
@@ -643,7 +642,7 @@ public class MandrillMessage {
 	public static class MessageContent {
 		private String name, type, content;
 		private Boolean binary;
-		
+
 		/**
 		 * @return The file name of the attachment.
 		 */
@@ -696,7 +695,7 @@ public class MandrillMessage {
 			this.binary = binary;
 		}
 	}
-	
+
 	/**
 	 * <p>A per-recipient merge variable.</p>
 	 * @author rschreijer
@@ -706,14 +705,14 @@ public class MandrillMessage {
 		private String rcpt;
 		private MergeVar[] vars;
 		/**
-		 * @return The email address of the recipient that 
+		 * @return The email address of the recipient that
 		 * the merge variables should apply to.
 		 */
 		public String getRcpt() {
 			return rcpt;
 		}
 		/**
-		 * @param rcpt The email address of the recipient that 
+		 * @param rcpt The email address of the recipient that
 		 * the merge variables should apply to.
 		 */
 		public void setRcpt(final String rcpt) {
@@ -732,7 +731,7 @@ public class MandrillMessage {
 			this.vars = vars;
 		}
 	}
-	
+
 	/**
 	 * <p>A single global merge variable.</p>
 	 * @author rschreijer
@@ -759,16 +758,16 @@ public class MandrillMessage {
 		}
 
 		/**
-		 * @return The merge variable's name. 
-		 * Merge variable names are case-insensitive 
+		 * @return The merge variable's name.
+		 * Merge variable names are case-insensitive
 		 * and may not start with _ (underline).
 		 */
 		public String getName() {
 			return name;
 		}
 		/**
-		 * @param name The merge variable's name. 
-		 * Merge variable names are case-insensitive 
+		 * @param name The merge variable's name.
+		 * Merge variable names are case-insensitive
 		 * and may not start with _ (underline).
 		 */
 		public void setName(final String name) {
@@ -787,7 +786,7 @@ public class MandrillMessage {
 			this.content = content;
 		}
 	}
-	
+
 	/**
 	 * <p>Metadata for a single recipient</p>
 	 * @author rschreijer
@@ -797,32 +796,32 @@ public class MandrillMessage {
 		private String rcpt;
 		private Map<String,String> values;
 		/**
-		 * @return The email address of the recipient 
+		 * @return The email address of the recipient
 		 * that the metadata is associated with.
 		 */
 		public String getRcpt() {
 			return rcpt;
 		}
 		/**
-		 * @param rcpt The email address of the recipient 
+		 * @param rcpt The email address of the recipient
 		 * that the metadata is associated with.
 		 */
 		public void setRcpt(final String rcpt) {
 			this.rcpt = rcpt;
 		}
 		/**
-		 * @return A map of user metadata. Mandrill will 
-		 * store this metadata and make it available for retrieval. In 
-		 * addition, you can select up to 10 metadata fields to index and 
+		 * @return A map of user metadata. Mandrill will
+		 * store this metadata and make it available for retrieval. In
+		 * addition, you can select up to 10 metadata fields to index and
 		 * make searchable using the Mandrill search api.
 		 */
 		public Map<String, String> getValues() {
 			return values;
 		}
 		/**
-		 * @param values A map of user metadata. Mandrill will 
-		 * store this metadata and make it available for retrieval. In 
-		 * addition, you can select up to 10 metadata fields to index and 
+		 * @param values A map of user metadata. Mandrill will
+		 * store this metadata and make it available for retrieval. In
+		 * addition, you can select up to 10 metadata fields to index and
 		 * make searchable using the Mandrill search api.
 		 */
 		public void setValues(final Map<String, String> values) {

--- a/src/test/java/com/microtripit/mandrillapp/lutung/MandrillApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/MandrillApiTest.java
@@ -1,10 +1,9 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -12,75 +11,75 @@ import org.junit.Test;
  * @since Mar 21, 2013
  */
 public final class MandrillApiTest extends MandrillTestCase {
-	
+
 	@Test
 	public final void testApiKey() {
 		final String key = mandrillApi.getKey();
 		Assert.assertNotNull(key);
 		Assert.assertFalse( key.isEmpty() );
-		Assert.assertFalse( key.equals("<put ur Mandrill API key here>") );
+		Assert.assertNotEquals("<put ur Mandrill API key here>", key);
 	}
-	
+
 	@Test
 	public final void testUsers() {
 		Assert.assertNotNull(mandrillApi.users());
 	}
-	
+
 	@Test
 	public final void testMessages() {
 		Assert.assertNotNull(mandrillApi.messages());
 	}
-	
+
 	@Test
 	public final void testTags() {
 		Assert.assertNotNull(mandrillApi.tags());
 	}
-	
+
 	@Test
 	public final void testRejects() {
 		Assert.assertNotNull(mandrillApi.rejects());
 	}
-	
+
 	@Test
 	public final void testWhitelists() {
 		Assert.assertNotNull(mandrillApi.whitelists());
 	}
-	
+
 	@Test
 	public final void testSenders() {
 		Assert.assertNotNull(mandrillApi.senders());
 	}
-	
+
 	@Test
 	public final void testUrls() {
 		Assert.assertNotNull(mandrillApi.urls());
 	}
-	
+
 	@Test
 	public final void testTemplates() {
 		Assert.assertNotNull(mandrillApi.templates());
 	}
-	
+
 	@Test
 	public final void testWebhooks() {
 		Assert.assertNotNull(mandrillApi.webhooks());
 	}
-	
+
 	@Test
 	public final void testSubaccounts() {
 		Assert.assertNotNull(mandrillApi.subaccounts());
 	}
-	
+
 	@Test
 	public final void testInbound() {
 		Assert.assertNotNull(mandrillApi.inbound());
 	}
-	
+
 	@Test
 	public final void testExports() {
 		Assert.assertNotNull(mandrillApi.exports());
 	}
-	
+
 	@Test
 	public final void testIps() {
 		Assert.assertNotNull(mandrillApi.ips());

--- a/src/test/java/com/microtripit/mandrillapp/lutung/MandrillTestCase.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/MandrillTestCase.java
@@ -1,12 +1,7 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
@@ -15,7 +10,10 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import com.microtripit.mandrillapp.lutung.MandrillApi;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author rschreijer
@@ -23,17 +21,17 @@ import com.microtripit.mandrillapp.lutung.MandrillApi;
  */
 public abstract class MandrillTestCase {
 	private static final Log log = LogFactory.getLog(MandrillApiTest.class);
-	
+
 	protected static MandrillApi mandrillApi;
-	
+
 	/**
 	 * <p>If you want to run your own tests, either provide a file
-	 * 'myapikey.txt' on your classpath, or simply change this 
+	 * 'myapikey.txt' on your classpath, or simply change this
 	 * method to return your hard-coded string.</p>
 	 * <p>If you provide a file, this file should ONLY contain your
-	 * Mandrill api key, as plain text in ONLY ONE line. This also 
+	 * Mandrill api key, as plain text in ONLY ONE line. This also
 	 * allows you to keep your api key secret since 'myapikey.txt'
-	 * is mentioned in .gitignore and will not be pushed to git!</p> 
+	 * is mentioned in .gitignore and will not be pushed to git!</p>
 	 * @return Your Mandrill API key.
 	 */
 	protected static final String getMandrillApiKey() {
@@ -48,7 +46,7 @@ public abstract class MandrillTestCase {
 						"a security measure ... I didn't want my own api key in " +
 						"a public git repo ;-)");
 			}
-			final String apikey = IOUtils.toString(is, Charset.forName("utf8"));
+			final String apikey = IOUtils.toString(is, StandardCharsets.UTF_8);
 			is.close();
 			if(apikey == null || apikey.isEmpty()) {
 				throw new IOException("Empty file 'myapikey.txt'");
@@ -63,7 +61,7 @@ public abstract class MandrillTestCase {
 
 		}
 	}
-	
+
 	@BeforeClass
 	public static final void runBeforeClass() {
 		final String key = getMandrillApiKey();
@@ -77,7 +75,7 @@ public abstract class MandrillTestCase {
 	protected static final String mailToAddress() {
 		return "lutung.mandrill@gmail.com";
 	}
-	
+
 	@Before
 	public final void runBefore() {
 		Assume.assumeNotNull(mandrillApi);

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillInboundApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillInboundApiTest.java
@@ -5,7 +5,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApiTest.java
@@ -3,10 +3,6 @@
  */
 package com.microtripit.mandrillapp.lutung.controller;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -20,7 +16,6 @@ import org.junit.Test;
 import com.microtripit.mandrillapp.lutung.MandrillTestCase;
 import com.microtripit.mandrillapp.lutung.model.LutungGsonUtils;
 import com.microtripit.mandrillapp.lutung.model.MandrillApiError;
-import com.microtripit.mandrillapp.lutung.model.MandrillApiError.MandrillError;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage.Recipient.Type;
@@ -31,7 +26,7 @@ import com.microtripit.mandrillapp.lutung.view.MandrillMessageStatus;
 import com.microtripit.mandrillapp.lutung.view.MandrillSearchMessageParams;
 import com.microtripit.mandrillapp.lutung.view.MandrillTemplate;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  * <p>Tests for the messages api implementations.</p>
@@ -51,7 +46,7 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
 	    Recipient to = new Recipient();
 	    to.setEmail(mailToAddress());
 	    to.setType(Type.TO);
-	    List<Recipient> recipients = new ArrayList<MandrillMessage.Recipient>();
+	    List<Recipient> recipients = new ArrayList<>();
 	    recipients.add(to);
 	    MandrillMessage message = new MandrillMessage();
 	    message.setFromEmail("from@test.com");
@@ -64,7 +59,7 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
 	@Test(expected=MandrillApiError.class)
 	public final void testSendTemplate01() throws IOException, MandrillApiError {
 		final HashMap<String,String> templateContent =
-				new HashMap<String,String>();
+			new HashMap<>();
 		templateContent.put("test", "value");
 		final MandrillMessage message = new MandrillMessage();
 		mandrillApi.messages().sendTemplate(null, templateContent, message, null);
@@ -74,7 +69,7 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
 	@Test(expected=MandrillApiError.class)
 	public final void testSendTemplate02() throws IOException, MandrillApiError {
 		final HashMap<String,String> templateContent =
-				new HashMap<String,String>();
+			new HashMap<>();
 		templateContent.put("test", "value");
 		mandrillApi.messages().sendTemplate("bvy38q34v93vzn39u4bvu9ewvbi349",
 				templateContent, null, null);
@@ -101,7 +96,7 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
         Recipient to = new Recipient();
         to.setEmail(mailToAddress());
         to.setType(Type.TO);
-        List<Recipient> recipients = new ArrayList<MandrillMessage.Recipient>();
+        List<Recipient> recipients = new ArrayList<>();
         recipients.add(to);
         MandrillMessage message = new MandrillMessage();
         message.setFromEmail("from@test.com");
@@ -173,10 +168,10 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
 		MandrillMessage parsedMessage = mandrillApi.messages().parse(null);
 		Assert.fail();
 	}
-	
+
 	@Test
 	public void testSmtpInfoResponse() {
-		String responseString = "{\"ts\":1234567890," 
+		String responseString = "{\"ts\":1234567890,"
 						+ "\"_id\":\"12345678901234567890123456789012\","
 						+ "\"state\":\"sent\","
 						+ "\"subject\":\"Subject\","
@@ -195,7 +190,7 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
 						+ "\"metadata\":{},"
 						+ "\"opens_detail\":[],"
 						+ "\"clicks_detail\":[]}";
-		
+
 		MandrillMessageInfo m = LutungGsonUtils.getGson().fromJson(responseString, MandrillMessageInfo.class);
         Assert.assertEquals(2, m.getSmtpEvents().size());
         SMTPEvent event = m.getSmtpEvents().get(1);
@@ -205,6 +200,6 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
         Assert.assertEquals("127.0.0.1", event.getSourceIp());
         Assert.assertEquals("127.0.0.2", event.getDestinationIp());
         Assert.assertEquals(12345, event.getSize());
-		
+
 	}
 }

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillRejectsApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillRejectsApiTest.java
@@ -5,7 +5,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillSendersApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillSendersApiTest.java
@@ -5,7 +5,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillTagsApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillTagsApiTest.java
@@ -5,7 +5,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApiTest.java
@@ -6,7 +6,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 import java.io.IOException;
 import java.util.HashMap;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 
@@ -52,9 +52,9 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 				"<html><body><h1>Hello World!</h1></body></html>", false, labels);
 		Assert.assertNotNull(t);
 		Assert.assertNotNull(t.getName());
-		Assert.assertTrue(t.getLabels().length == 2);
-		Assert.assertTrue(t.getLabels()[0].equals(label1));
-		Assert.assertTrue(t.getLabels()[1].equals(label2));
+		Assert.assertEquals(2, t.getLabels().length);
+		Assert.assertEquals(t.getLabels()[0], label1);
+		Assert.assertEquals(t.getLabels()[1], label2);
 		Assert.assertNotNull( mandrillApi.templates().delete(t.getName()) );
 	}
 
@@ -73,7 +73,7 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 
 		final MandrillTemplate[] templates = mandrillApi.templates().list();
 		Assert.assertNotNull(templates);
-		Assert.assertTrue(templates.length == (startinTemplates.length + 2));
+		Assert.assertEquals(templates.length, (startinTemplates.length + 2));
 		t1 = mandrillApi.templates().delete(t1.getName());
 		Assert.assertNotNull(t1);
 		t2 = mandrillApi.templates().delete(t2.getName());
@@ -98,11 +98,11 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 
 		final MandrillTemplate[] templatesFound1 = mandrillApi.templates().list(label1);
 		Assert.assertNotNull(templatesFound1);
-		Assert.assertTrue(templatesFound1.length == 1);
+		Assert.assertEquals(1, templatesFound1.length);
 
 		final MandrillTemplate[] templatesFound2 = mandrillApi.templates().list(label2);
 		Assert.assertNotNull(templatesFound2);
-		Assert.assertTrue(templatesFound2.length == 1);
+		Assert.assertEquals(1, templatesFound2.length);
 
 		t1 = mandrillApi.templates().delete(t1.getName());
 		Assert.assertNotNull(t1);
@@ -176,9 +176,9 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 		Assert.assertNotNull(t.getName());
 		Assert.assertEquals(updatedCode, t.getCode());
 		Assert.assertNotNull(t.getCreatedAt());
-		Assert.assertTrue(t.getLabels().length == 2);
-		Assert.assertTrue(t.getLabels()[0].equals(label1));
-		Assert.assertTrue(t.getLabels()[1].equals(label3));
+		Assert.assertEquals(2, t.getLabels().length);
+		Assert.assertEquals(t.getLabels()[0], label1);
+		Assert.assertEquals(t.getLabels()[1], label3);
 		Assert.assertNotNull( mandrillApi.templates().delete(t.getName()) );
 	}
 
@@ -255,7 +255,7 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 
 		mandrillApi.templates().render(
 				null,
-				new HashMap<String,String>(),
+			new HashMap<>(),
 				null);
 		Assert.fail();
 
@@ -277,9 +277,9 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 		MandrillTemplate t = mandrillApi.templates().add(templateName,
 				code, false);
 		Assert.assertNotNull(t);
-		final HashMap<String, String> content = new HashMap<String,String>();
+		final HashMap<String, String> content = new HashMap<>();
 		content.put("editable", "<div>foo *|MERGE2|*</div>");
-		final HashMap<String, String> mergeVars = new HashMap<String, String>();
+		final HashMap<String, String> mergeVars = new HashMap<>();
 		mergeVars.put("merge1", "Lutung");
 		mergeVars.put("merge2", "bar");
 		final String rendered = mandrillApi.templates().render(

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillUrlsApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillUrlsApiTest.java
@@ -5,7 +5,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillUsersApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillUsersApiTest.java
@@ -5,7 +5,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillWebhooksApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillWebhooksApiTest.java
@@ -5,7 +5,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillWhitelistsApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillWhitelistsApiTest.java
@@ -2,7 +2,7 @@ package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 


### PR DESCRIPTION
This solves:

[PR-107](https://github.com/rschreijer/lutung/pull/107)
[PR-104](https://github.com/rschreijer/lutung/pull/104)

In the original (unmaintained repo). 

I also thought it might be good to slightly modernize the repo by introducing java8 support (especially since `commons-io:2.5` is the last version of `commons-io` compatible with java 6). 

@dnovitski Please let me know if you think java 6 support is still relevant. and I'd revert most of the changes.