### PR TITLE
add new fields to MandrillMessageInfo and MandrillMessageStatus

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageInfo.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageInfo.java
@@ -13,12 +13,13 @@ import java.util.Map;
  */
 public class MandrillMessageInfo {
     private Long ts;
-	private Integer opens, clicks;
-	private String _id, sender, template, subject, email, state;
+	private Integer opens, clicks, bgtools_code;
+	private String _id, sender, template, subject, email, state, diag;
 	private List<String> tags;
 	private List<UserActionDetail> opens_detail, clicks_detail;
 	private List<SMTPEvent> smtp_events;
 	private Map<String,String> metadata;
+	private MandrillRejectsEntry reject;
 
 	/**
 	 * @return The Unix timestamp from when this message was sent.
@@ -100,6 +101,18 @@ public class MandrillMessageInfo {
 	 */
 	public Map<String,String> getMetadata() {
 		return metadata;
+	}
+
+	public Integer getBgtoolsCode() {
+		return bgtools_code;
+	}
+
+	public String getDiag() {
+		return diag;
+	}
+
+	public MandrillRejectsEntry getReject() {
+		return reject;
 	}
 
 	public static class UserActionDetail {

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageStatus.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageStatus.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.view;
 
@@ -9,7 +9,7 @@ package com.microtripit.mandrillapp.lutung.view;
  * @since Mar 16, 2013
  */
 public class MandrillMessageStatus {
-	private String email, status, reject_reason, _id;
+	private String email, status, reject_reason, queued_reason, _id;
 
 	/**
 	 * @return The email address of the recipient.
@@ -19,19 +19,31 @@ public class MandrillMessageStatus {
 	}
 
 	/**
-	 * @return The sending status of the recipient &ndash; 
+	 * @return The sending status of the recipient &ndash;
 	 * either 'sent', 'queued', 'rejected', or 'invalid'.
 	 */
 	public String getStatus() {
 		return status;
 	}
-	
+
 	/**
-	 * @return The reason for the rejection if the recipient 
+	 * @return The reason for the rejection if the recipient
 	 * status is 'rejected'.
 	 */
 	public String getRejectReason() {
 		return reject_reason;
+	}
+
+	/**
+	 * @return The reason for the email being queued if the response status is "queued"
+	 * Possible values: "attachments", "multiple-recipients",
+	 * "free-trial-sends-exhausted", "hourly-quota-exhausted",
+	 * "monthly-limit-reached", "sending-paused",
+	 * "sending-suspended", "account-suspended",
+	 * 	or "sending-backlogged".
+	 */
+	public String getQueuedReason() {
+		return queued_reason;
 	}
 
 	/**
@@ -40,5 +52,5 @@ public class MandrillMessageStatus {
 	public String getId() {
 		return _id;
 	}
-	
+
 }


### PR DESCRIPTION
When I use this project, it does not receive all return values from the Mandrill API. I think some fields are still important.
eg: MandrillMessageStatus.queued_reason, MandrillMessageInfo.reject.